### PR TITLE
bug shifted sum signals relative to cell ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Iniatialization of this CHANGELOG file to track changes as the version increments
 
+## [0.1.1] - 2019-10-03
+### Added
+- Fixed bug in sum signal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Iniatialization of this CHANGELOG file to track changes as the version increments
 
 ## [0.1.1] - 2019-10-03
-### Added
+### Fixed
 - Fixed bug in sum signal

--- a/merlin/analysis/sequential.py
+++ b/merlin/analysis/sequential.py
@@ -76,7 +76,7 @@ class SumSignal(analysistask.ParallelAnalysisTask):
             data=[(propsDict[k].intensity_image.sum(),
                    propsDict[k].filled_area)
                   if k in propsDict else (0, 0)
-                  for k in range(len(cellCoords))],
+                  for k in range(1, len(cellCoords) + 1)],
             index=cellIDs,
             columns=['Intensity', 'Pixels'])
         return propsOut


### PR DESCRIPTION
The draw contours call labels everything with i+1, so the first cell is 1. When you loop over len(cellcoords) it starts at 0, so the first cell's ID is mistakenly given (0,0) since it isn't in region props, and then it stops 1 cell before the end, so the lengths still match up, but everyone is shifted by 1.