### PR TITLE
improving barcode assignments for cells overlapping fovs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Exposed tolerance parameter in the adaptive filter barcodes method
 - Added plot for scale factor magnitude vs bit index
+- Fixed barcode partitioning to include cells from adjacent fields of view when a cell falls across fov boundaries

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -52,7 +52,7 @@ class IncompatibleVersionException(Exception):
 
 def version():
     import pkg_resources
-    return pkg_resources.require("merlin")[0].version
+    return pkg_resources.get_distribution('merlin').version
 
 
 def is_compatible(testVersion: str, baseVersion: str = None) -> bool:

--- a/merlin/analysis/partition.py
+++ b/merlin/analysis/partition.py
@@ -66,7 +66,7 @@ class PartitionBarcodes(analysistask.ParallelAnalysisTask):
             if fi == fovIntersections[0]:
                 currentFOVBarcodes = partialBC.copy(deep=True)
             else:
-                currentFOVBarcodes = pd.concat(
+                currentFOVBarcodes = pandas.concat(
                     [currentFOVBarcodes, partialBC], 0)
 
         currentFOVBarcodes = currentFOVBarcodes.reset_index().copy(deep=True)


### PR DESCRIPTION
Trying to update barcode partitioning to account for cells that overlap FOVs. Originally, partition would only call up the barcodes from the fov a cell was assigned to, so when a cell spans two or more fovs it does not get barcodes from the non-assigned fov even if they are contained within it's boundaries.