### PR TITLE
Parallel cleancell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added option to draw field of view labels overlaid on the mosaic
 
+## [0.1.4] - 2019-12-05
+### Changed
+- Changed the clean overlapping cells to run in parallel

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -101,7 +101,12 @@ Parameters:
 segment.CleanCellBoundaries
 --------------------------------
 
-Description: Assigns each cell to the FOV centroid they are closest to, and eliminates overlapping cells, preferentially removing cells that overlap with the largest number of other cells until there is no more overlap in a given group of cells.
+Description: For a FOV of interest, this task identifies all other FOVs with any overlapping regions, and constructs a graph containing cells from the FOV of interest and all cells from either that FOV or the overlapping FOVs that overlap a cell, with edges connecting overlapping cells
+
+segment.CombineCleanedBoundaries
+--------------------------------
+
+Description: Combines the cleaned cell boundaries generated for each fov, and eliminates overlapping cells, preferentially removing cells that overlap with the largest number of other cells until there is no more overlap in a given group of cells.
 
 segment.RefineCellDatabases
 --------------------------------

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -120,9 +120,10 @@ class SimpleGlobalAlignment(GlobalAlignment):
         Returns:
             a list of four floats, representing the xmin, xmax, ymin, ymax
         """
-
+        imageDimensions = self.dataSet.get_image_dimensions()
         return [x for y in (self.fov_coordinates_to_global(fov, (0, 0)),
-                            self.fov_coordinates_to_global(fov, (2048, 2048)))
+                            self.fov_coordinates_to_global(
+                                fov, (imageDimensions[0], imageDimensions[1])))
                 for x in y]
 
     def global_coordinates_to_fov(self, fov, globalCoordinates):

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -14,6 +14,8 @@ class GlobalAlignment(analysistask.AnalysisTask):
     different field of views relative to each other in order to construct
     a global alignment.
     """
+    def __init__(self, dataSet, parameters=None, analysisName=None):
+        super().__init__(dataSet, parameters, analysisName)
 
     @abstractmethod
     def fov_coordinates_to_global(
@@ -74,7 +76,6 @@ class GlobalAlignment(analysistask.AnalysisTask):
         """
         pass
 
-    @abstractmethod
     def get_fov_boxes(self) -> List:
         """
         Creates a list of shapely boxes for each fov containing the global
@@ -83,7 +84,10 @@ class GlobalAlignment(analysistask.AnalysisTask):
         Returns:
             A list of shapely boxes
         """
-        pass
+        fovs = self.dataSet.get_fovs()
+        boxes = [geometry.box(*self.fov_global_extent(f)) for f in fovs]
+
+        return boxes
 
 
 
@@ -168,12 +172,6 @@ class SimpleGlobalAlignment(GlobalAlignment):
         maxY = np.max([x[1] for x in fovBounds])
 
         return minX, minY, maxX, maxY
-
-    def get_fov_boxes(self) -> List:
-        fovs = self.dataSet.get_fovs()
-        boxes = [geometry.box(*self.fov_global_extent(f)) for f in fovs]
-
-        return boxes
 
 
 class CorrelationGlobalAlignment(GlobalAlignment):

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 import numpy as np
 from typing import Tuple
 from typing import List
+from shapely import geometry
 
 from merlin.core import analysistask
 
@@ -170,12 +171,7 @@ class SimpleGlobalAlignment(GlobalAlignment):
 
     def get_fov_boxes(self) -> List:
         fovs = self.dataSet.get_fovs()
-        coords = [self.fov_global_extent(f) for f in fovs]
-        coordsDF = pandas.DataFrame(coords,
-                                    columns=['minx', 'miny', 'maxx', 'maxy'],
-                                    index=fovs)
-        boxes = [geometry.box(x[0], x[1], x[2], x[3]) for x in
-                 coordsDF.loc[:, ['minx', 'miny', 'maxx', 'maxy']].values]
+        boxes = [geometry.box(*self.fov_global_extent(f)) for f in fovs]
 
         return boxes
 

--- a/merlin/analysis/partition.py
+++ b/merlin/analysis/partition.py
@@ -56,8 +56,7 @@ class PartitionBarcodes(analysistask.ParallelAnalysisTask):
         alignTask = self.dataSet.load_analysis_task(
             self.parameters['alignment_task'])
 
-        fovBoxes = spatialfeature.get_fov_boxes(self.dataSet.get_fovs(),
-                                                alignTask)
+        fovBoxes = alignTask.get_fov_boxes()
         fovIntersections = sorted([i for i, x in enumerate(fovBoxes) if
                                    fovBoxes[fragmentIndex].intersects(x)])
 

--- a/merlin/analysis/partition.py
+++ b/merlin/analysis/partition.py
@@ -2,7 +2,7 @@ import pandas
 import numpy as np
 
 from merlin.core import analysistask
-
+from merlin.util import spatialfeature
 
 class PartitionBarcodes(analysistask.ParallelAnalysisTask):
 
@@ -26,7 +26,7 @@ class PartitionBarcodes(analysistask.ParallelAnalysisTask):
     def get_dependencies(self):
         return [self.parameters['filter_task'],
                 self.parameters['assignment_task'],
-                self.parameters['cleaning_task']]
+                self.parameters['alignment_task']]
 
     def get_partitioned_barcodes(self, fov: int = None) -> pandas.DataFrame:
         """Retrieve the cell by barcode matrixes calculated from this
@@ -53,10 +53,11 @@ class PartitionBarcodes(analysistask.ParallelAnalysisTask):
             self.parameters['filter_task'])
         assignmentTask = self.dataSet.load_analysis_task(
             self.parameters['assignment_task'])
-        cleaningTask = self.dataSet.load_analysis_task(
-            self.parameters['cleaning_task'])
+        alignTask = self.dataSet.load_analysis_task(
+            self.parameters['alignment_task'])
 
-        fovBoxes = cleaningTask.get_fov_boxes()
+        fovBoxes = spatialfeature.get_fov_boxes(self.dataSet.get_fovs(),
+                                                alignTask)
         fovIntersections = sorted([i for i, x in enumerate(fovBoxes) if
                                    fovBoxes[fragmentIndex].intersects(x)])
 

--- a/merlin/analysis/segment.py
+++ b/merlin/analysis/segment.py
@@ -168,8 +168,6 @@ class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
 
     def _run_analysis(self, fragmentIndex) -> None:
         allFOVs = np.array(self.dataSet.get_fovs())
-        alignTask = self.dataSet.load_analysis_task(
-            self.parameters['global_align_task'])
         fovBoxes = self.alignTask.get_fov_boxes()
         fovIntersections = sorted([i for i, x in enumerate(fovBoxes) if
                                    fovBoxes[fragmentIndex].intersects(x)])

--- a/merlin/analysis/segment.py
+++ b/merlin/analysis/segment.py
@@ -170,7 +170,7 @@ class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
         allFOVs = np.array(self.dataSet.get_fovs())
         alignTask = self.dataSet.load_analysis_task(
             self.parameters['global_align_task'])
-        fovBoxes = spatialfeature.get_fov_boxes(allFOVs, alignTask)
+        fovBoxes = self.alignTask.get_fov_boxes()
         fovIntersections = sorted([i for i, x in enumerate(fovBoxes) if
                                    fovBoxes[fragmentIndex].intersects(x)])
         intersectingFOVs = list(allFOVs[np.array(fovIntersections)])
@@ -199,6 +199,14 @@ class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
 
 
 class CombineCleanedBoundaries(analysistask.AnalysisTask):
+    """
+    A task to construct a network graph where each cell is a node, and overlaps
+    are represented by edges. This graph is then refined to assign cells to the
+    fov they are closest to (in terms of centroid). This graph is then refined
+    to eliminate overlapping cells to leave a single cell occupying a given
+    position.
+
+    """
     def __init__(self, dataSet, parameters=None, analysisName=None):
         super().__init__(dataSet, parameters, analysisName)
 

--- a/merlin/analysis/segment.py
+++ b/merlin/analysis/segment.py
@@ -197,6 +197,7 @@ class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
         self._write_graph(graph, 'cleaned_cells',
                           self.analysisName, fragmentIndex)
 
+
 class CombineCleanedBoundaries(analysistask.AnalysisTask):
     def __init__(self, dataSet, parameters=None, analysisName=None):
         super().__init__(dataSet, parameters, analysisName)
@@ -231,7 +232,6 @@ class CombineCleanedBoundaries(analysistask.AnalysisTask):
 
         self.dataSet.save_dataframe_to_csv(cleanedCells, 'all_cleaned_cells',
                                            analysisTask=self)
-
 
 
 class RefineCellDatabases(FeatureSavingAnalysisTask):

--- a/merlin/analysis/segment.py
+++ b/merlin/analysis/segment.py
@@ -120,7 +120,7 @@ class WatershedSegment(FeatureSavingAnalysisTask):
             for z in range(len(self.dataSet.get_z_positions()))])
 
 
-class CleanCellBoundaries(analysistask.AnalysisTask):
+class CleanCellBoundaries(analysistask.ParallelAnalysisTask):
     '''
     A task to construct a network graph where each cell is a node, and overlaps
     are represented by edges. This graph is then refined to assign cells to the
@@ -135,6 +135,9 @@ class CleanCellBoundaries(analysistask.AnalysisTask):
             self.parameters['segment_task'])
         self.alignTask = self.dataSet.load_analysis_task(
             self.parameters['global_align_task'])
+
+    def fragment_count(self):
+        return len(self.dataSet.get_fovs())
 
     def get_estimated_memory(self):
         return 2048
@@ -157,35 +160,35 @@ class CleanCellBoundaries(analysistask.AnalysisTask):
 
         return boxes
 
-    def _construct_fov_tree(self, tiledPositions: pandas.DataFrame,
-                            fovIntersections: List):
-        return cKDTree(data=tiledPositions.loc[fovIntersections,
-                                               ['centerX', 'centerY']].values)
+    def _write_graph(self, analysisResult: nx.Graph, resultName: str,
+                     analysisName: str, resultIndex: int = None,
+                     subdirectory: str = None) -> None:
+        graphOut = nx.readwrite.json_graph.jit_data(analysisResult)
 
-    def _intial_clean(self, currentFOV: int):
-        currentCells = self.segmentTask.get_feature_database()\
-            .read_features(currentFOV)
-        return [cell for cell in currentCells
-                if len(cell.get_bounding_box()) == 4 and cell.get_volume() > 0]
+        savePath = self.dataSet._analysis_result_save_path(
+            resultName, analysisName, resultIndex, subdirectory, '.json')
+        with open(savePath, 'w') as f:
+            outfile.write(graphOut, f)
 
-    def _append_cells_to_spatial_tree(self, tree: rtree.index.Index,
-                                      cells: List, idToNum: Dict):
-        for element in cells:
-            tree.insert(idToNum[element.get_feature_id()],
-                        element.get_bounding_box(), obj=element)
+    def return_exported_data(self, fragmentIndex) -> nx.Graph:
+        f = self.dataSet.load_json_analysis_result('cleanecells',
+                                                   self.analysisName,
+                                                   fragmentIndex, None)
+        loadedG = nx.readwrite.json_graph.jit_graph(f, create_using=nx.Graph())
 
-    def return_exported_data(self):
-        kwargs = {'index_col': 0}
-        return self.dataSet.load_dataframe_from_csv(
-            'cleanedcells', analysisTask=self.analysisName, **kwargs)
+        return loadedG
 
-    def _run_analysis(self) -> None:
+    def _run_analysis(self, fragmentIndex) -> None:
+        allFOVs = np.array(self.dataSet.get_fovs())
+        fovBoxes = self.get_fov_boxes()
+        fovIntersections = sorted([i for i, x in enumerate(fovBoxes) if
+                                   fovBoxes[fragmentIndex].intersects(x)])
+        intersectingFOVs = list(allFOVs[np.array(fovIntersections)])
 
         spatialTree = rtree.index.Index()
         count = 0
         idToNum = dict()
-        allFOVs = self.dataSet.get_fovs()
-        for currentFOV in allFOVs:
+        for currentFOV in intersectingFOVs:
             cells = self.segmentTask.get_feature_database()\
                 .read_features(currentFOV)
             cells = spatialfeature.simple_clean_cells(cells)
@@ -193,20 +196,52 @@ class CleanCellBoundaries(analysistask.AnalysisTask):
             spatialTree, count, idToNum = spatialfeature.construct_tree(
                 cells, spatialTree, count, idToNum)
 
-        fovBoxes = self.get_fov_boxes()
+        graph = nx.Graph()
+        cells = self.segmentTask.get_feature_database()\
+            .read_features(fragmentIndex)
+        cells = spatialfeature.simple_clean_cells(cells)
+        graph = spatialfeature.construct_graph(graph, cells,
+                                               spatialTree, fragmentIndex,
+                                               allFOVs, fovBoxes)
+
+        self._write_graph(self, graph, 'cleanedcells',
+                          self.analysisName, fragmentIndex)
+
+class CombineCleanedBoundaries(analysistask.AnalysisTask):
+    def __init__(self, dataSet, parameters=None, analysisName=None):
+        super().__init__(dataSet, parameters, analysisName)
+
+        self.cleaningTask = self.dataSet.load_analysis_task(
+            self.parameters['cleaning_task'])
+
+    def get_estimated_memory(self):
+        # TODO - refine estimate
+        return 2048
+
+    def get_estimated_time(self):
+        # TODO - refine estimate
+        return 5
+
+    def get_dependencies(self):
+        return [self.parameters['cleaning_task']]
+
+    def return_exported_data(self):
+        kwargs = {'index_col': 0}
+        return self.dataSet.load_dataframe_from_csv(
+            'allcleanedcells', analysisTask=self.analysisName, **kwargs)
+
+    def _run_analysis(self):
+        allFOVs = self.dataSet.get_fovs()
         graph = nx.Graph()
         for currentFOV in allFOVs:
-            cells = self.segmentTask.get_feature_database()\
-                .read_features(currentFOV)
-            cells = spatialfeature.simple_clean_cells(cells)
-            graph = spatialfeature.construct_graph(graph, cells,
-                                                   spatialTree, currentFOV,
-                                                   allFOVs, fovBoxes)
+            subGraph = self.cleaningTask.return_exported_data(currentFOV)
+            graph = nx.compose(graph, subGraph)
 
         cleanedCells = spatialfeature.remove_overlapping_cells(graph)
 
-        self.dataSet.save_dataframe_to_csv(cleanedCells, 'cleanedcells',
+        self.dataSet.save_dataframe_to_csv(cleanedCells, 'allcleanedcells',
                                            analysisTask=self)
+
 
 
 class RefineCellDatabases(FeatureSavingAnalysisTask):
@@ -216,7 +251,7 @@ class RefineCellDatabases(FeatureSavingAnalysisTask):
         self.segmentTask = self.dataSet.load_analysis_task(
             self.parameters['segment_task'])
         self.cleaningTask = self.dataSet.load_analysis_task(
-            self.parameters['cleaning_task'])
+            self.parameters['combine_cleaning_task'])
 
     def fragment_count(self):
         return len(self.dataSet.get_fovs())
@@ -231,7 +266,7 @@ class RefineCellDatabases(FeatureSavingAnalysisTask):
 
     def get_dependencies(self):
         return [self.parameters['segment_task'],
-                self.parameters['cleaning_task']]
+                self.parameters['combine_cleaning_task']]
 
     def _run_analysis(self, fragmentIndex):
 

--- a/merlin/util/spatialfeature.py
+++ b/merlin/util/spatialfeature.py
@@ -635,6 +635,7 @@ def simple_clean_cells(cells: List) -> List:
     return [cell for cell in cells
             if len(cell.get_bounding_box()) == 4 and cell.get_volume() > 0]
 
+
 def get_fov_boxes(fovs: List, alignTask: analysistask.AnalysisTask) -> List:
     """
     Creates a list of shapely boxes for each fov containing the global
@@ -655,6 +656,7 @@ def get_fov_boxes(fovs: List, alignTask: analysistask.AnalysisTask) -> List:
              coordsDF.loc[:, ['minx', 'miny', 'maxx', 'maxy']].values]
 
     return boxes
+
 
 def append_cells_to_spatial_tree(tree: rtree.index.Index,
                                  cells: List, idToNum: Dict):

--- a/merlin/util/spatialfeature.py
+++ b/merlin/util/spatialfeature.py
@@ -636,28 +636,6 @@ def simple_clean_cells(cells: List) -> List:
             if len(cell.get_bounding_box()) == 4 and cell.get_volume() > 0]
 
 
-def get_fov_boxes(fovs: List, alignTask: analysistask.AnalysisTask) -> List:
-    """
-    Creates a list of shapely boxes for each fov containing the global
-    coordinates as the box coordinates.
-
-    Args:
-        fovs: A list of fovs to create boxes for
-        alignTask: a globalalign task to get global coordinates for each fov
-
-    Returns:
-        A list of shapely boxes
-    """
-    coords = [alignTask.fov_global_extent(f) for f in fovs]
-    coordsDF = pandas.DataFrame(coords,
-                                columns=['minx', 'miny', 'maxx', 'maxy'],
-                                index=fovs)
-    boxes = [geometry.box(x[0], x[1], x[2], x[3]) for x in
-             coordsDF.loc[:, ['minx', 'miny', 'maxx', 'maxy']].values]
-
-    return boxes
-
-
 def append_cells_to_spatial_tree(tree: rtree.index.Index,
                                  cells: List, idToNum: Dict):
     for element in cells:

--- a/merlin/util/spatialfeature.py
+++ b/merlin/util/spatialfeature.py
@@ -634,6 +634,26 @@ def simple_clean_cells(cells: List) -> List:
     return [cell for cell in cells
             if len(cell.get_bounding_box()) == 4 and cell.get_volume() > 0]
 
+def get_fov_boxes(fovs: List, alignTask: analysistask.AnalysisTask) -> List:
+    """
+    Creates a list of shapely boxes for each fov containing the global
+    coordinates as the box coordinates.
+
+    Args:
+        fovs: A list of fovs to create boxes for
+        alignTask: a globalalign task to get global coordinates for each fov
+
+    Returns:
+        A list of shapely boxes
+    """
+    coords = [alignTask.fov_global_extent(f) for f in fovs]
+    coordsDF = pandas.DataFrame(coords,
+                                columns=['minx', 'miny', 'maxx', 'maxy'],
+                                index=fovs)
+    boxes = [geometry.box(x[0], x[1], x[2], x[3]) for x in
+             coordsDF.loc[:, ['minx', 'miny', 'maxx', 'maxy']].values]
+
+    return boxes
 
 def append_cells_to_spatial_tree(tree: rtree.index.Index,
                                  cells: List, idToNum: Dict):

--- a/merlin/util/spatialfeature.py
+++ b/merlin/util/spatialfeature.py
@@ -16,6 +16,7 @@ from scipy.spatial import cKDTree
 
 
 from merlin.core import dataset
+from merlin.core import analysistask
 
 
 class SpatialFeature(object):

--- a/test/auxiliary_files/test_analysis_parameters.json
+++ b/test/auxiliary_files/test_analysis_parameters.json
@@ -121,11 +121,18 @@
             }
         },
         {
+            "task": "CombineCleanedBoundaries",
+            "module": "merlin.analysis.segment",
+            "parameters": {
+                "cleaning_task": "CleanCellBoundaries"
+            }
+        },
+        {
             "task": "RefineCellDatabases",
             "module": "merlin.analysis.segment",
             "parameters": {
                 "segment_task": "WatershedSegment",
-                "cleaning_task": "CleanCellBoundaries"
+                "combine_cleaning_task": "CombineCleanedBoundaries"
             }
         },
         {
@@ -134,7 +141,7 @@
             "parameters": {
                 "filter_task": "AdaptiveFilterBarcodes",
                 "assignment_task": "RefineCellDatabases",
-                "cleaning_task": "CleanCellBoundaries"
+                "alignment_task": "SimpleGlobalAlignment"
             }
         },
         {


### PR DESCRIPTION
The updated clean cell boundaries is relatively slow by virtue of running as a single task looping through each fov. I realized I could make it parallel if I constructed a graph of cells and their overlaps for a FOV of interest so long as I considered cells in that FOV and all overlapping FOVs (as those are the only places where cells could overlap). I then combine all the graphs into a single graph, eliminate overlapping cells, and then refine the spatial feature databases as before. I also cleaned up some instances of duplicated code from spatialfeature and segment that I'd missed in the earlier PR.