### PR TITLE
Fix bug in GenerateAdaptiveThreshold, avoids crash when resubmit

### DIFF
--- a/merlin/analysis/filterbarcodes.py
+++ b/merlin/analysis/filterbarcodes.py
@@ -261,7 +261,7 @@ class GenerateAdaptiveThreshold(analysistask.AnalysisTask):
         updated = False
         while not all(completeFragments):
             if (intensityBins is None or 
-                blankCounts is None or codingCounts is None):
+                    blankCounts is None or codingCounts is None):
                 for i in range(self.fragment_count()):
                     if not pendingFragments[i] and decodeTask.is_complete(i):
                         pendingFragments[i] = decodeTask.is_complete(i)

--- a/merlin/analysis/filterbarcodes.py
+++ b/merlin/analysis/filterbarcodes.py
@@ -260,7 +260,7 @@ class GenerateAdaptiveThreshold(analysistask.AnalysisTask):
 
         updated = False
         while not all(completeFragments):
-            if (intensityBins is None or 
+            if (intensityBins is None or
                     blankCounts is None or codingCounts is None):
                 for i in range(self.fragment_count()):
                     if not pendingFragments[i] and decodeTask.is_complete(i):

--- a/merlin/analysis/filterbarcodes.py
+++ b/merlin/analysis/filterbarcodes.py
@@ -260,7 +260,7 @@ class GenerateAdaptiveThreshold(analysistask.AnalysisTask):
 
         updated = False
         while not all(completeFragments):
-            if intensityBins is None:
+            if intensityBins is None or blankCounts is None or codingCounts is None:
                 for i in range(self.fragment_count()):
                     if not pendingFragments[i] and decodeTask.is_complete(i):
                         pendingFragments[i] = decodeTask.is_complete(i)

--- a/merlin/analysis/filterbarcodes.py
+++ b/merlin/analysis/filterbarcodes.py
@@ -260,7 +260,8 @@ class GenerateAdaptiveThreshold(analysistask.AnalysisTask):
 
         updated = False
         while not all(completeFragments):
-            if intensityBins is None or blankCounts is None or codingCounts is None:
+            if (intensityBins is None or 
+                blankCounts is None or codingCounts is None):
                 for i in range(self.fragment_count()):
                     if not pendingFragments[i] and decodeTask.is_complete(i):
                         pendingFragments[i] = decodeTask.is_complete(i)


### PR DESCRIPTION
Solves a bug in GenerateAdaptiveThreshold that makes MERlin crash when .npy files have been creasted by previous runs. I tested it and solves the issue.