### PR TITLE
Updated aws bucket name.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scipy>=1.2
 matplotlib
 networkx
 rtree
-shapely!=1.7a2
+shapely<1.7a2
 seaborn>=0.9.0
 pyqt5
 Sphinx

--- a/test/test_dataportal.py
+++ b/test/test_dataportal.py
@@ -23,7 +23,7 @@ def local_data_portal():
 
 
 def s3_data_portal():
-    yield dataportal.S3DataPortal('s3://merlin-test-bucket/test-files',
+    yield dataportal.S3DataPortal('s3://merlin-test-bucket-vg/test-files',
                                   region_name='us-east-2',
                                   config=Config(signature_version=UNSIGNED))
 


### PR DESCRIPTION
The previous bucket s3://merlin-test-bucket appears to no longer be available so I redirected this to a new test bucket containing the same files.