### PR TITLE
Decode faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.5] - 2020-01-22
 ### Changed
 - Updated the filemap to only store the file name so that it can easily be pointed to new data home directories. This change maintains backward compatibility.
+- Improved decoding speed

--- a/merlin/analysis/decode.py
+++ b/merlin/analysis/decode.py
@@ -207,7 +207,7 @@ class Decode(BarcodeSavingParallelAnalysisTask):
         minimumArea = self.parameters['minimum_area']
 
         self.get_barcode_database().write_barcodes(
-            pandas.concat([decoder.extract_barcodes_with_index(
+            pandas.concat([decoder.extract_barcodes_with_index_inbatch(
                 i, decodedImage, pixelMagnitudes, pixelTraces, distances, fov,
                 self.cropWidth, zIndex, globalTask, None, minimumArea)
                 for i in range(self.get_codebook().get_barcode_count())]),

--- a/merlin/analysis/decode.py
+++ b/merlin/analysis/decode.py
@@ -207,8 +207,8 @@ class Decode(BarcodeSavingParallelAnalysisTask):
         minimumArea = self.parameters['minimum_area']
 
         self.get_barcode_database().write_barcodes(
-            pandas.concat([decoder.extract_barcodes_with_index_inbatch(
+            pandas.concat([decoder.extract_barcodes_with_index(
                 i, decodedImage, pixelMagnitudes, pixelTraces, distances, fov,
-                self.cropWidth, zIndex, globalTask, None, minimumArea)
+                self.cropWidth, zIndex, globalTask, minimumArea)
                 for i in range(self.get_codebook().get_barcode_count())]),
             fov=fov)

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -128,7 +128,8 @@ class SimpleGlobalAlignment(GlobalAlignment):
 
     def fov_coordinate_array_to_global(self, fov: int,
                                        fovCoordArray: np.array) -> np.array:
-        """A matrix based transformation of fov coordiantes to global coordiantes
+        """A matrix based transformation of fov coordinates to
+           global coordinates.
         Args:
             fov: the fov of interest
             fovCoordArray: numpy array of the [z, x, y] positions to transform

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -126,6 +126,23 @@ class SimpleGlobalAlignment(GlobalAlignment):
                     fovStart[0] + fovCoordinates[1]*micronsPerPixel,
                     fovStart[1] + fovCoordinates[2]*micronsPerPixel)
 
+    def fov_coordinate_array_to_global(self, fov: int,
+                                       fovCoordArray: np.array) -> np.array:
+        """A matrix based transformation of fov coordiantes to global coordiantes
+        Args:
+            fov: the fov of interest
+            fovCoordArray: numpy array of the [z, x, y] positions to transform
+        Returns:
+            numpy array of the global [z, x, y] coordinates
+        """
+        tForm = self.fov_to_global_transform(fov)
+        toGlobal = np.ones(fovCoordArray.shape)
+        toGlobal[:, [0, 1]] = fovCoordArray[:, [1, 2]]
+        globalCentroids = np.matmul(tForm, toGlobal.T).T[:, [2, 0, 1]]
+        globalCentroids[:, 0] = fovCoordArray[:, 0]
+        return globalCentroids
+
+
     def fov_global_extent(self, fov: int) -> List[float]:
 
         """

--- a/merlin/analysis/globalalign.py
+++ b/merlin/analysis/globalalign.py
@@ -76,6 +76,19 @@ class GlobalAlignment(analysistask.AnalysisTask):
         """
         pass
 
+    @abstractmethod
+    def fov_coordinate_array_to_global(self, fov: int,
+                                       fovCoordArray: np.array) -> np.array:
+        """A bulk transformation of a list of fov coordinates to
+           global coordinates.
+        Args:
+            fov: the fov of interest
+            fovCoordArray: numpy array of the [z, x, y] positions to transform
+        Returns:
+            numpy array of the global [z, x, y] coordinates
+        """
+        pass
+
     def get_fov_boxes(self) -> List:
         """
         Creates a list of shapely boxes for each fov containing the global
@@ -88,7 +101,6 @@ class GlobalAlignment(analysistask.AnalysisTask):
         boxes = [geometry.box(*self.fov_global_extent(f)) for f in fovs]
 
         return boxes
-
 
 
 class SimpleGlobalAlignment(GlobalAlignment):
@@ -128,14 +140,6 @@ class SimpleGlobalAlignment(GlobalAlignment):
 
     def fov_coordinate_array_to_global(self, fov: int,
                                        fovCoordArray: np.array) -> np.array:
-        """A matrix based transformation of fov coordinates to
-           global coordinates.
-        Args:
-            fov: the fov of interest
-            fovCoordArray: numpy array of the [z, x, y] positions to transform
-        Returns:
-            numpy array of the global [z, x, y] coordinates
-        """
         tForm = self.fov_to_global_transform(fov)
         toGlobal = np.ones(fovCoordArray.shape)
         toGlobal[:, [0, 1]] = fovCoordArray[:, [1, 2]]
@@ -143,11 +147,9 @@ class SimpleGlobalAlignment(GlobalAlignment):
         globalCentroids[:, 0] = fovCoordArray[:, 0]
         return globalCentroids
 
-
     def fov_global_extent(self, fov: int) -> List[float]:
-
         """
-        Returns the global extent of an fov, output interleaved as
+        Returns the global extent of a fov, output interleaved as
         xmin, ymin, xmax, ymax
 
         Args:
@@ -220,6 +222,10 @@ class CorrelationGlobalAlignment(GlobalAlignment):
         raise NotImplementedError
 
     def get_global_extent(self):
+        raise NotImplementedError
+
+    def fov_coordinate_array_to_global(self, fov: int,
+                                       fovCoordArray: np.array) -> np.array:
         raise NotImplementedError
 
     @staticmethod

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -31,9 +31,7 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         if 'optimize_chromatic_correction' not in self.parameters:
             self.parameters['optimize_chromatic_correction'] = False
         if 'crop_width' not in self.parameters:
-            self.parameters['crop_width'] = 100
-
-        self.cropWidth = self.parameters['crop_width']
+            self.parameters['crop_width'] = 0
 
     def get_estimated_memory(self):
         return 4000
@@ -101,9 +99,10 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
 
         # TODO this saves the barcodes under fragment instead of fov
         # the barcodedb should be made more general
+        cropWidth = self.parameters['crop_width']
         self.get_barcode_database().write_barcodes(
             pandas.concat([decoder.extract_barcodes_with_index(
-                i, di, pm, npt, d, fovIndex, self.cropWidth,
+                i, di, pm, npt, d, fovIndex, cropWidth,
                 zIndex, minimumArea=areaThreshold)
                 for i in range(codebook.get_barcode_count())]),
             fov=fragmentIndex)

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -397,3 +397,37 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
                 self.parameters['previous_iteration']
             ).get_barcode_count_history()
             return np.append(previousHistory, [countsMean], axis=0)
+
+
+class OptimizeConvergence(OptimizeIteration):
+
+    """
+    An analysis task for performing a single iteration of scale factor
+    optimization.
+    """
+
+    def __init__(self, dataSet, parameters=None, analysisName=None):
+        super().__init__(dataSet, parameters, analysisName)
+
+        if 'fov_per_iteration' not in self.parameters:
+            self.parameters['fov_per_iteration'] = 50
+        if 'area_threshold' not in self.parameters:
+            self.parameters['area_threshold'] = 5
+        if 'optimize_background' not in self.parameters:
+            self.parameters['optimize_background'] = False
+        if 'optimize_chromatic_correction' not in self.parameters:
+            self.parameters['optimize_chromatic_correction'] = False
+
+    def get_estimated_memory(self):
+        return 4000
+
+    def get_estimated_time(self):
+        return 1000
+
+    def get_dependencies(self):
+        dependencies = [self.parameters['preprocess_task'],
+                        self.parameters['warp_task']]
+        if 'previous_iteration' in self.parameters:
+            dependencies += [self.parameters['previous_iteration']]
+        return dependencies
+

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -30,6 +30,10 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
             self.parameters['optimize_background'] = False
         if 'optimize_chromatic_correction' not in self.parameters:
             self.parameters['optimize_chromatic_correction'] = False
+        if 'crop_width' not in self.parameters:
+            self.parameters['crop_width'] = 100
+
+        self.cropWidth = self.parameters['crop_width']
 
     def get_estimated_memory(self):
         return 4000
@@ -98,9 +102,9 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         # TODO this saves the barcodes under fragment instead of fov
         # the barcodedb should be made more general
         self.get_barcode_database().write_barcodes(
-            pandas.concat([decoder.extract_barcodes_with_index_inbatch(
-                i, di, pm, npt, d, fovIndex,
-                10, zIndex, minimumArea=areaThreshold)
+            pandas.concat([decoder.extract_barcodes_with_index(
+                i, di, pm, npt, d, fovIndex, self.cropWidth,
+                zIndex, minimumArea=areaThreshold)
                 for i in range(codebook.get_barcode_count())]),
             fov=fragmentIndex)
         self.dataSet.save_numpy_analysis_result(

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -397,37 +397,3 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
                 self.parameters['previous_iteration']
             ).get_barcode_count_history()
             return np.append(previousHistory, [countsMean], axis=0)
-
-
-class OptimizeConvergence(OptimizeIteration):
-
-    """
-    An analysis task for performing a single iteration of scale factor
-    optimization.
-    """
-
-    def __init__(self, dataSet, parameters=None, analysisName=None):
-        super().__init__(dataSet, parameters, analysisName)
-
-        if 'fov_per_iteration' not in self.parameters:
-            self.parameters['fov_per_iteration'] = 50
-        if 'area_threshold' not in self.parameters:
-            self.parameters['area_threshold'] = 5
-        if 'optimize_background' not in self.parameters:
-            self.parameters['optimize_background'] = False
-        if 'optimize_chromatic_correction' not in self.parameters:
-            self.parameters['optimize_chromatic_correction'] = False
-
-    def get_estimated_memory(self):
-        return 4000
-
-    def get_estimated_time(self):
-        return 1000
-
-    def get_dependencies(self):
-        dependencies = [self.parameters['preprocess_task'],
-                        self.parameters['warp_task']]
-        if 'previous_iteration' in self.parameters:
-            dependencies += [self.parameters['previous_iteration']]
-        return dependencies
-

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -98,7 +98,7 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         # TODO this saves the barcodes under fragment instead of fov
         # the barcodedb should be made more general
         self.get_barcode_database().write_barcodes(
-            pandas.concat([decoder.extract_barcodes_with_index(
+            pandas.concat([decoder.extract_barcodes_with_index_inbatch(
                 i, di, pm, npt, d, fovIndex,
                 10, zIndex, minimumArea=areaThreshold)
                 for i in range(codebook.get_barcode_count())]),

--- a/merlin/util/decoding.py
+++ b/merlin/util/decoding.py
@@ -166,12 +166,11 @@ class PixelBasedDecoder(object):
             measure.label(decodedImage == barcodeIndex),
             intensity_image=pixelMagnitudes,
             cache=False)
-        is3D = len(pixelTraces.shape) == 3
+        is3D = len(pixelTraces.shape) == 4
 
         columnNames = ['barcode_id', 'fov', 'mean_intensity', 'max_intensity',
-         'area', 'mean_distance', 'min_distance',
-         'x', 'y', 'z', 'global_x', 'global_y', 'global_z',
-         'cell_index']
+                       'area', 'mean_distance', 'min_distance', 'x', 'y', 'z',
+                       'global_x', 'global_y', 'global_z', 'cell_index']
         if is3D:
             intensityColumns = ['intensity_{}'.format(i) for i in
                                 range(pixelTraces.shape[1])]
@@ -202,11 +201,11 @@ class PixelBasedDecoder(object):
             intensityAndCoords = [
                 np.array([[y[0], y[1], pixelMagnitudes[y[0], y[1]]] for y in x])
                 for x in allCoords]
-            centroidCoords = np.array([[(r[:, 0] * (
-                        r[:, -1] / r[:, -1].sum())).sum(), (r[:, 1] * (
-                        r[:, -1] / r[:, -1].sum())).sum()] if r.shape[0] > 1
-                                       else [r[0][0], r[0][1]]
-                                       for r in intensityAndCoords])
+            centroidCoords = np.array(
+                [[(r[:, 0] * (r[:, -1] / r[:, -1].sum())).sum(),
+                  (r[:, 1] * (r[:, -1] / r[:, -1].sum())).sum()]
+                 if r.shape[0] > 1 else [r[0][0], r[0][1]]
+                 for r in intensityAndCoords])
             centroids = np.zeros((centroidCoords.shape[0], 3))
             centroids[:, 0] = zIndex
             centroids[:, [1, 2]] = centroidCoords[:, [1, 0]]


### PR DESCRIPTION
I profiled the decoding code and found that the bulk of the time was spent running decoding._bc_properties_to_dict(). I refactored this a bit to cut the time down as much as I could. There's some additional tweaking I might want to do to see if I can reduce it further, but if you have comments let me know.

In terms of performance, I find that returning the set of barcodes for a given gene takes about 10-fold less time, and overall decoding runs 5-6-fold faster.