### PR TITLE
Add deterministic option for OptimizeIteration

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -56,7 +56,8 @@ Description: Determines the optimal per-bit scale factors for barcode decoding.
 Parameters:
 
 * iteration\_count -- The number of iterations to perform for the optimization.
-* fov\_per\_iteration -- The number of fields of view to decode in each round of optimization.
+* fov\_index -- (Optional) A list of [[fov_1, z_value_1], [fov_2, z_value_2], ..] specifying which fields of view and what z values should be used for optimization.
+* fov\_per\_iteration -- The number of fields of view to decode in each round of optimization. This will be set to the length of ``fov_index`` if the ``fov_index`` is specified.
 * estimate\_initial\_scale\_factors\_from\_cdf -- Flag indicating if the initial scale factors should be estimated from the pixel intensity cdf. If false, the initial scale factors are all set to 1. If true, the initial scale factors are based on the 90th percentile of the pixe intensity cdf.
 * area\_threshold -- The minimum barcode area for barcodes to be used in the calculation of the scale factors.
 

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -57,7 +57,7 @@ Parameters:
 
 * iteration\_count -- The number of iterations to perform for the optimization.
 * fov\_index -- (Optional) A list of [[fov_1, z_value_1], [fov_2, z_value_2], ..] specifying which fields of view and what z values should be used for optimization.
-* fov\_per\_iteration -- The number of fields of view to decode in each round of optimization. This will be set to the length of ``fov_index`` if the ``fov_index`` is specified.
+* fov\_per\_iteration -- The number of fields of view to decode in each round of optimization. This will be set to the length of ``fov_index`` if the ``fov_index`` parameter is specified.
 * estimate\_initial\_scale\_factors\_from\_cdf -- Flag indicating if the initial scale factors should be estimated from the pixel intensity cdf. If false, the initial scale factors are all set to 1. If true, the initial scale factors are based on the 90th percentile of the pixe intensity cdf.
 * area\_threshold -- The minimum barcode area for barcodes to be used in the calculation of the scale factors.
 

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -32,6 +32,12 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
             self.parameters['optimize_chromatic_correction'] = False
         if 'crop_width' not in self.parameters:
             self.parameters['crop_width'] = 0
+        if 'fov_index' in self.parameters:
+            # Set iterations number to length of fov_index if not
+            # None. Should we warn the user?
+            #
+            self.parameters['fov_per_iteration'] = \
+                len(self.parameters['fov_index'])
 
     def get_estimated_memory(self):
         return 4000
@@ -59,9 +65,25 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
                 self.parameters['preprocess_task'])
         codebook = self.get_codebook()
 
-        fovIndex = np.random.choice(list(self.dataSet.get_fovs()))
-        zIndex = np.random.choice(
-            list(range(len(self.dataSet.get_z_positions()))))
+        # Use random FOV and Z index if the user did not specify.
+        if 'fov_index' not in self.parameters:
+            fovIndex = np.random.choice(list(self.dataSet.get_fovs()))
+            zIndex = np.random.choice(
+                list(range(len(self.dataSet.get_z_positions()))))
+
+        # Otherwise use FOV and Z indices specified by the user.
+        else:
+            tmp = self.parameters['fov_index'][fragmentIndex]
+
+            # Two element list is FOV, z index.
+            if isinstance(tmp, list):
+                fovIndex = tmp[0]
+                zIndex = tmp[1]
+
+            # Otherwise this is the FOV index.
+            else:
+                fovIndex = tmp
+                zIndex = 0
 
         scaleFactors = self._get_previous_scale_factors()
         backgrounds = self._get_previous_backgrounds()

--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -32,14 +32,14 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
             self.parameters['optimize_chromatic_correction'] = False
         if 'crop_width' not in self.parameters:
             self.parameters['crop_width'] = 0
-            
+
         if 'fov_index' in self.parameters:
             logger = self.dataSet.get_logger(self)
             logger.info('Setting fov_per_iteration to length of fov_index')
 
             self.parameters['fov_per_iteration'] = \
                 len(self.parameters['fov_index'])
-            
+
         else:
             self.parameters['fov_index'] = []
             for i in range(self.parameters['fov_per_iteration']):


### PR DESCRIPTION
This adds an optional 'fov_index' parameter for `OptimizeIteration`. If specified then `OptimizeIteration` uses the values in `fov_index` for selecting FOV and Z indexs instead of doing this randomly.

If an element in the `fov_index` list is a number than this is the FOV index and the Z index is always 0. If an element in the `fov_index` list is also a list then the first element of the list is the FOV index and the second element is the Z index.

Examples:
* `"fov_index" : [0, 1, 2, 3]` - Optimize on FOV 0,1,2,3 with Z index 0.
* `"fov_index" : [[0, 0], [1, 1], [2,2], [3, 3]]` - Optimize on FOV 0,1,2,3 with Z index 0,1,2,3.
* `"fov_index" : [0, 1, 2, [3,1]]` - Optimize on FOV 0,1,2,3 with Z index 0, 0, 0, 1.

