### PR TITLE
Remove list comprehensions to improve performance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ single task or split among many subtasks that can be executed in parallel. MERli
 execute workflows on a single computer, on a high performance cluster, or on the cloud 
 (AWS and Google Cloud).
 
+If MERlin is useful for your research, consider citing:
+Emanuel, G., Eichhorn, S. W., Zhuang, X. 2020, MERlin - scalable and extensible MERFISH analysis software, v0.1.6, Zenodo, doi:10.5281/zenodo.3758540 
+
 Please find the most recent version of MERlin [here](https://github.com/emanuega/merlin).
 
 ## MERFISH data analysis

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/emanuega/MERlin/tree/master.svg?style=svg)](https://circleci.com/gh/emanuega/MERlin/tree/master)
 [![codecov](https://codecov.io/gh/emanuega/MERlin/branch/master/graph/badge.svg)](https://codecov.io/gh/emanuega/MERlin)
+[![DOI](https://zenodo.org/badge/202668055.svg)](https://zenodo.org/badge/latestdoi/202668055)
 
 # MERlin - Extensible pipeline for scalable data analysis
 

--- a/license.md
+++ b/license.md
@@ -1,129 +1,21 @@
-**Academic and/or Non-Commercial Research Use Software License and Terms of
-Use**
+The MIT License
 
-This Agreement concerns MERLIN (the “Software”), useful for analysis of images
-obtained using MERFISH. The Software was developed by George Emanuel, Stephen
-Eichhorn, and Xiaowei Zhuang at Harvard University.
+Copyright (c) 2019 Harvard University
 
-Using the Software indicates your agreement to be bound by the terms of this
-Software Use Agreement (“Agreement”). Absent your agreement to the terms below,
-you (the “End User”) have no rights to hold or use the Software whatsoever.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-President and Fellows of Harvard College (“Harvard”) agrees to grant hereunder
-the limited non-exclusive license to End User for the use of the Software in the
-performance of End User’s internal, non-commercial research and/or academic use
-at End User’s institution or company (“Institution”) on the following terms and
-conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-1.  **NO REDISTRIBUTION.** The Software remains the property of Harvard, and
-    except as set forth in Section 4, End User shall not publish, distribute, or
-    otherwise transfer or make available the Software to any other party.
-
-2.  **NO COMMERCIAL USE.** End User shall not use the Software for commercial
-    purposes and any such use of the Software is expressly prohibited. This
-    prohibition includes, but is not limited to, use of the Software in
-    fee-for-service arrangements or to provide research services to (or in
-    collaboration with) third parties for a fee. This prohibition does not
-    extend to use for internal research purposes within a for-profit entity. If
-    End User wishes to use the Software for commercial purposes prohibited
-    herein, or for any other restricted purpose, End User must execute a
-    separate license agreement with Harvard.
-
-    >   *Requests for use of the Software for or on behalf of for-profit entities or
-    >   for any commercial purposes, please contact*:
-    >
-    >   Office of Technology Development  
-       Harvard University  
-       Smith Campus Center, Suite 727E  
-       1350 Massachusetts Avenue  
-       Cambridge, MA 02138 USA  
-       Telephone: (617) 495-3067  
-       E-mail: otd\@harvard.edu  
-
-3.  **OWNERSHIP AND COPYRIGHT NOTICE.** Harvard owns all intellectual property
-    in the Software. End User shall gain no ownership to the Software. End User
-    shall not remove or delete and shall retain in the Software, in any
-    modifications to Software and in any Derivative Works, the copyright,
-    trademark, or other notices pertaining to Software as provided with the
-    Software.
-
-4.  **DERIVATIVE WORKS.** End User may create and use Derivative Works, as such
-    term is defined under U.S. copyright laws, provided that any such Derivative
-    Works shall be restricted to non-commercial, internal research and/or
-    academic use at End User’s Institution. End User may distribute Derivative
-    Works to other institutions solely for the performance of non-commercial,
-    internal research and/or academic use on terms substantially similar to this
-    License and Terms of Use.
-
-5.  **FEEDBACK.** In order to improve the Software, comments from End Users may
-    be useful. End User agrees to provide Harvard with feedback on the End
-    User’s use of the Software (e.g., any bugs in the Software, the user
-    experience, etc.). Harvard is permitted to use such information provided by
-    End User in making changes and improvements to the Software without
-    compensation or an accounting to End User.
-
-6.  **NON ASSERT.** End User acknowledges that Harvard may develop modifications
-    to the Software that may be based on the feedback provided by End User under
-    Section 5 above. Harvard shall not be restricted in any way by End User
-    regarding the use of such information. End User acknowledges the right of
-    Harvard to prepare, publish, display, reproduce, transmit and or use
-    modifications to the Software that may be substantially similar or
-    functionally equivalent to End User’s modifications and/or improvements if
-    any. In the event that End User obtains patent protection for any
-    modification or improvement to Software, End User agrees not to allege or
-    enjoin infringement of End User’s patent against Harvard or any of its
-    researchers, medical or research staff, officers, directors and employees.
-
-7.  **PUBLICATION & ATTRIBUTION.** End User has the right to publish, present,
-    or share results from the use of the Software.  In accordance with customary
-    academic practice, End User will acknowledge Xiaowei Zhuang Laboratory at
-    Harvard as the provider of the Software.
-
-8.  **NO WARRANTIES.** THE SOFTWARE IS PROVIDED "AS IS." TO THE FULLEST EXTENT
-    PERMITTED BY LAW, HARVARD HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND
-    (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SOFTWARE, INCLUDING BUT NOT
-    LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-    PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. HARVARD MAKES NO
-    WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS,
-    SUFFICIENCY OR QUALITY OF THE SOFTWARE. HARVARD DOES NOT WARRANT THAT THE
-    SOFTWARE WILL OPERATE WITHOUT ERROR OR INTERRUPTION.
-
-9.  **Limitations of Liability and Remedies**. USE OF THE SOFTWARE IS AT END
-    USER’S OWN RISK. IF END USER IS DISSATISFIED WITH THE SOFTWARE, ITS
-    EXCLUSIVE REMEDY IS TO STOP USING IT. IN NO EVENT SHALL HARVARD BE LIABLE TO
-    END USER OR ITS INSTITUTION, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT,
-    INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR OTHER DAMAGES OF
-    ANY KIND WHATSOEVER ARISING OUT OF OR IN CONNECTION WITH THE SOFTWARE, EVEN
-    IF HARVARD IS NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS OF WHETHER
-    HARVARD IS ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-10.  **INDEMNIFICATION.** To the extent permitted by law, End User shall
-    indemnify, defend and hold harmless Harvard and its current or future
-    directors, trustees, officers, faculty, medical and professional staff,
-    employees, students and agents and their respective successors, heirs and
-    assigns (the "Indemnitees"), against any liability, damage, loss or expense
-    (including reasonable attorney's fees and expenses of litigation) incurred
-    by or imposed upon the Indemnitees or any one of them in connection with any
-    claims, suits, actions, demands or judgments arising from End User’s breach
-    of this Agreement or its Institution’s use of the Software except to the
-    extent caused by the gross negligence or willful misconduct of Harvard. This
-    indemnification provision shall survive expiration or termination of this
-    Agreement.
-
-11.  **GOVERNING LAW.** This Agreement shall be construed and governed by the
-    laws of the Commonwealth of Massachusetts regardless of otherwise applicable
-    choice of law standards.
-
-12. **NON-USE OF NAME.** Nothing in this License and Terms of Use shall be
-    construed as granting End Users or their Institutions any rights or licenses
-    to use any trademarks, service marks or logos associated with the Software.
-    You may not use the terms “Harvard” (or a substantially similar term) in any
-    way that is inconsistent with the permitted uses described herein. You agree
-    not to use any name or emblem of Harvard or any of its subdivisions for any
-    purpose, or to falsely suggest any relationship between End User (or its
-    Institution) and Harvard, or in any manner that would infringe or violate
-    any of Harvard’s rights.
-
-13. End User represents and warrants that it has the legal authority to enter
-    into this License and Terms of Use on behalf of itself and its Institution.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/merlin/util/decoding.py
+++ b/merlin/util/decoding.py
@@ -25,7 +25,8 @@ def normalize(x):
 class PixelBasedDecoder(object):
 
     def __init__(self, codebook: mcodebook.Codebook,
-                 scaleFactors: np.ndarray=None, backgrounds: np.ndarray=None):
+                 scaleFactors: np.ndarray = None,
+                 backgrounds: np.ndarray = None):
         self._codebook = codebook
         self._decodingMatrix = self._calculate_normalized_barcodes()
         self._barcodeCount = self._decodingMatrix.shape[0]
@@ -44,11 +45,11 @@ class PixelBasedDecoder(object):
         self.refactorAreaThreshold = 4
 
     def decode_pixels(self, imageData: np.ndarray,
-                      scaleFactors: np.ndarray=None,
-                      backgrounds: np.ndarray=None,
-                      distanceThreshold: float=0.5176,
-                      magnitudeThreshold: float=1,
-                      lowPassSigma: float=1):
+                      scaleFactors: np.ndarray = None,
+                      backgrounds: np.ndarray = None,
+                      distanceThreshold: float = 0.5176,
+                      magnitudeThreshold: float = 1,
+                      lowPassSigma: float = 1):
         """Assign barcodes to the pixels in the provided image stock.
 
         Each pixel is assigned to the nearest barcode from the codebook if
@@ -74,16 +75,16 @@ class PixelBasedDecoder(object):
             lowPassSigma: standard deviation for the low pass filter that is
                 applied to the images prior to decoding.
         Returns:
-            Four results are returned as a tuple (decodedImage, pixelMagnitudes,
-                normalizedPixelTraces, distances). decodedImage is an image
-                indicating the barcode index assigned to each pixel. Pixels
-                for which a barcode is not assigned have a value of -1.
-                pixelMagnitudes is an image where each pixel is the norm of
-                the pixel trace after scaling by the provided scaleFactors.
-                normalizedPixelTraces is an image stack containing the
-                normalized intensities for each pixel. distances is an
-                image containing the distance for each pixel to the assigned
-                barcode.
+            Four results are returned as a tuple (decodedImage,
+                pixelMagnitudes, normalizedPixelTraces, distances).
+                decodedImage is an image indicating the barcode index assigned
+                to each pixel. Pixels for which a barcode is not assigned have
+                a value of -1. pixelMagnitudes is an image where each pixel is
+                the norm of the pixel trace after scaling by the provided
+                scaleFactors. normalizedPixelTraces is an image stack
+                containing the normalized intensities for each pixel. distances
+                is an image containing the distance for each pixel to the
+                assigned barcode.
         """
         if scaleFactors is None:
             scaleFactors = self._scaleFactors
@@ -96,15 +97,17 @@ class PixelBasedDecoder(object):
             filteredImages[i, :, :] = cv2.GaussianBlur(
                 imageData[i, :, :], (filterSize, filterSize), lowPassSigma)
 
-        pixelTraces = np.reshape(
-                filteredImages, 
-                (filteredImages.shape[0], np.prod(filteredImages.shape[1:])))
-        scaledPixelTraces = np.transpose(
-                np.array([(p-b)/s for p, s, b in zip(pixelTraces, scaleFactors,
-                                                   backgrounds)]))
+        scaleFactors = scaleFactors.astype(np.float32)
+        backgrounds = backgrounds.astype(np.float32)
 
-        pixelMagnitudes = np.array(
-            [np.linalg.norm(x) for x in scaledPixelTraces], dtype=np.float32)
+        pixelTraces = np.reshape(
+                filteredImages,
+                (filteredImages.shape[0], np.prod(filteredImages.shape[1:])))
+
+        scaledPixelTraces = np.transpose(pixelTraces).astype(np.float32)
+        scaledPixelTraces = (scaledPixelTraces - backgrounds)/scaleFactors
+        pixelMagnitudes = \
+            np.linalg.norm(scaledPixelTraces, axis=1).astype(np.float32)
         pixelMagnitudes[pixelMagnitudes == 0] = 1
 
         normalizedPixelTraces = scaledPixelTraces/pixelMagnitudes[:, None]
@@ -115,10 +118,9 @@ class PixelBasedDecoder(object):
         distances, indexes = neighbors.kneighbors(
                 normalizedPixelTraces, return_distance=True)
 
-        decodedImage = np.reshape(
-            np.array([i[0] if d[0] <= distanceThreshold else -1
-                      for i, d in zip(indexes, distances)], dtype=np.int16),
-            filteredImages.shape[1:])
+        decodedImage = indexes.astype(np.int16)
+        decodedImage[distances > distanceThreshold] = -1
+        decodedImage = np.reshape(decodedImage, filteredImages.shape[1:])
 
         pixelMagnitudes = np.reshape(pixelMagnitudes, filteredImages.shape[1:])
         normalizedPixelTraces = np.moveaxis(normalizedPixelTraces, 1, 0)
@@ -133,8 +135,8 @@ class PixelBasedDecoder(object):
     def extract_barcodes_with_index(
             self, barcodeIndex: int, decodedImage: np.ndarray,
             pixelMagnitudes: np.ndarray, pixelTraces: np.ndarray,
-            distances: np.ndarray, fov: int, cropWidth: int, zIndex: int = None,
-            globalAligner=None, minimumArea: int = 0
+            distances: np.ndarray, fov: int, cropWidth: int,
+            zIndex: int = None, globalAligner=None, minimumArea: int = 0
     ) -> pandas.DataFrame:
         """Extract the barcode information from the decoded image for barcodes
         that were decoded to the specified barcode index.
@@ -151,8 +153,8 @@ class PixelBasedDecoder(object):
             distances: an image indicating the distance between the normalized
                 pixel trace and the assigned barcode for each pixel
             fov: the index of the field of view
-            cropWidth: the number of pixels around the edge of each image within
-                which barcodes are excluded from the output list.
+            cropWidth: the number of pixels around the edge of each image
+                within which barcodes are excluded from the output list.
             zIndex: the index of the z position
             globalAligner: the aligner used for converted to local x,y
                 coordinates to global x,y coordinates
@@ -199,7 +201,8 @@ class PixelBasedDecoder(object):
 
         else:
             intensityAndCoords = [
-                np.array([[y[0], y[1], pixelMagnitudes[y[0], y[1]]] for y in x])
+                np.array([[y[0], y[1],
+                           pixelMagnitudes[y[0], y[1]]] for y in x])
                 for x in allCoords]
             centroidCoords = np.array(
                 [[(r[:, 0] * (r[:, -1] / r[:, -1].sum())).sum(),
@@ -260,16 +263,16 @@ class PixelBasedDecoder(object):
             ignoreBlanks: Flag to set if the barcodes corresponding to blanks
                 should be ignored. If True, barcodes corresponding to a name
                 that contains 'Blank' are ignored.
-            includeErrors: Flag to set if barcodes corresponding to single bit 
+            includeErrors: Flag to set if barcodes corresponding to single bit
                 errors should be added.
         Returns:
             A 2d numpy array where each row is a normalized barcode and each
                 column is the corresponding normalized bit value.
         """
-        
+
         barcodeSet = self._codebook.get_barcodes(ignoreBlanks=ignoreBlanks)
         magnitudes = np.sqrt(np.sum(barcodeSet*barcodeSet, axis=1))
-       
+
         if not includeErrors:
             weightedBarcodes = np.array(
                 [normalize(x) for x, m in zip(barcodeSet, magnitudes)])
@@ -289,7 +292,7 @@ class PixelBasedDecoder(object):
 
     def extract_refactors(
             self, decodedImage, pixelMagnitudes, normalizedPixelTraces,
-            extractBackgrounds = False
+            extractBackgrounds=False
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Calculate the scale factors that would result in the mean
         on bit intensity for each bit to be equal.
@@ -349,8 +352,8 @@ class PixelBasedDecoder(object):
             imageSet: the image stack to decode in order to determine the
                 scale factors
         Returns:
-            an array of the backgrounds where the i'th entry is the scale factor
-                for bit i.
+            an array of the backgrounds where the i'th entry is the scale
+                factor for bit i.
         """
         sumMinPixelTraces = np.zeros((self._barcodeCount, self._bitCount))
         barcodesSeen = np.zeros(self._barcodeCount)


### PR DESCRIPTION
At least on my laptop the `decode_pixels()` method of `PixelBasedDecoder` spends about half it's time doing list comprehensions and the other half actually decoding. So this pull request replaces all the list comprehensions with numpy array/matrix manipulations, making it about 2x faster. Your mileage may vary?