### PR TITLE
Include package data when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setuptools.setup(
     entry_points={
         'console_scripts': ["merlin=merlin.merlin:merlin"]
     },
-    classifiers=CLASSIFIERS
+    include_package_data=True,
+    classifiers=CLASSIFIERS,
 )


### PR DESCRIPTION
Currently, as the instructions say, this package has to be installed in "developer mode" i.e. checking out the code somewhere and linking.

This PR solves the issue of installing the package properly with pip install. This allows the posibility of properly packaging this and submitting it to Pypi.