### PR TITLE
Allow custom location of environment file

### DIFF
--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -7,7 +7,9 @@ from typing import List
 
 from merlin.core import dataset
 
-envPath = os.path.join(os.path.expanduser('~'), '.merlinenv')
+envPath = os.path.join(
+    os.getenv("MERLIN_ENV_PATH") or os.path.expanduser("~"), ".merlinenv"
+)
 
 if os.path.exists(envPath):
     dotenv.load_dotenv(envPath)


### PR DESCRIPTION
Currently the environment file `.merlinenv` **has** to be located in the user's home directory. This is somewhat inconvenient in some cases. 

The current PR adds support for using an optional environment variable `MERLIN_ENV_PATH` pointing to the location of the `.merlinenv` file and fails back to the user's home if not present. 