### PR TITLE
Fix package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ setuptools>=36.0.0
 urllib3
 python-dotenv>=0.8.2
 pandas>=0.23.4
-tifffile>=0.14.0
+tifffile==0.14.0
 opencv-python>=3
-scikit-image>=0.15.0
+scikit-image>=0.15.0,<0.16
 scikit-learn>=0.19.0
 numpy>1.16.0
 scipy>=1.2
@@ -22,7 +22,7 @@ pytest-cov
 h5py>=1.8.15
 numexpr>=2.6.2
 cython>=0.21
-snakemake
+snakemake==5.26.1
 requests>=2.18.0
 tables
 boto3


### PR DESCRIPTION
Currently merlin does not work out of the box due to package updates.

This PR pins a few package versions to old versions so that it works. Probably it fixes #70 